### PR TITLE
Feature/observer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,4 @@ Repositório com as implementações dos padrões de projeto explorados no Lab "
 - Singleton
 - Strategy/Repository
 - Facade
+- Observer

--- a/src/main/java/one/digitalinnovation/gof/service/ClienteEventPublisher.java
+++ b/src/main/java/one/digitalinnovation/gof/service/ClienteEventPublisher.java
@@ -1,0 +1,18 @@
+package one.digitalinnovation.gof.service;
+
+import one.digitalinnovation.gof.model.Cliente;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class ClienteEventPublisher {
+
+    @Autowired
+    private List<ClienteObserver> observers;
+
+    public void notificarTodos(Cliente cliente, String evento){
+        observers.forEach(observer -> observer.notificar(cliente, evento));
+    }
+}

--- a/src/main/java/one/digitalinnovation/gof/service/ClienteObserver.java
+++ b/src/main/java/one/digitalinnovation/gof/service/ClienteObserver.java
@@ -1,0 +1,9 @@
+package one.digitalinnovation.gof.service;
+
+import one.digitalinnovation.gof.model.Cliente;
+
+public interface ClienteObserver {
+
+    void notificar (Cliente cliente, String evento);
+
+}

--- a/src/main/java/one/digitalinnovation/gof/service/impl/AuditoriaObserver.java
+++ b/src/main/java/one/digitalinnovation/gof/service/impl/AuditoriaObserver.java
@@ -1,0 +1,15 @@
+package one.digitalinnovation.gof.service.impl;
+
+import one.digitalinnovation.gof.model.Cliente;
+import one.digitalinnovation.gof.service.ClienteObserver;
+
+import java.time.LocalDateTime;
+
+public class AuditoriaObserver  implements ClienteObserver {
+
+    @Override
+    public void notificar(Cliente cliente, String evento) {
+        System.out.printf("[AUDITORIA] %s - Cliente '%s' (id=%d) foi %s.%n", LocalDateTime.now(), cliente.getNome(), cliente.getId(), evento);
+    }
+
+}

--- a/src/main/java/one/digitalinnovation/gof/service/impl/ClienteServiceImpl.java
+++ b/src/main/java/one/digitalinnovation/gof/service/impl/ClienteServiceImpl.java
@@ -2,6 +2,7 @@ package one.digitalinnovation.gof.service.impl;
 
 import java.util.Optional;
 
+import one.digitalinnovation.gof.service.ClienteEventPublisher;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -23,12 +24,14 @@ import one.digitalinnovation.gof.service.ViaCepService;
 public class ClienteServiceImpl implements ClienteService {
 
 	// Singleton: Injetar os componentes do Spring com @Autowired.
-	@Autowired
-	private ClienteRepository clienteRepository;
-	@Autowired
-	private EnderecoRepository enderecoRepository;
-	@Autowired
-	private ViaCepService viaCepService;
+    @Autowired
+    private ClienteRepository clienteRepository;
+    @Autowired
+    private EnderecoRepository enderecoRepository;
+    @Autowired
+    private ViaCepService viaCepService;
+    @Autowired
+    private ClienteEventPublisher clienteEventPublisher;
 	
 	// Strategy: Implementar os métodos definidos na interface.
 	// Facade: Abstrair integrações com subsistemas, provendo uma interface simples.
@@ -49,21 +52,26 @@ public class ClienteServiceImpl implements ClienteService {
 	@Override
 	public void inserir(Cliente cliente) {
 		salvarClienteComCep(cliente);
+        clienteEventPublisher.notificarTodos(cliente, "CRIADO");
 	}
 
 	@Override
 	public void atualizar(Long id, Cliente cliente) {
 		// Buscar Cliente por ID, caso exista:
-		Optional<Cliente> clienteBd = clienteRepository.findById(id);
-		if (clienteBd.isPresent()) {
-			salvarClienteComCep(cliente);
-		}
+        Optional<Cliente> clienteBd = clienteRepository.findById(id);
+        if (clienteBd.isPresent()) {
+            salvarClienteComCep(cliente);
+            clienteEventPublisher.notificarTodos(cliente, "ATUALIZADO");
+        }
 	}
 
 	@Override
 	public void deletar(Long id) {
+
+        Optional<Cliente> clienteBd = clienteRepository.findById(id);
 		// Deletar Cliente por ID.
 		clienteRepository.deleteById(id);
+        clienteBd.ifPresent(cliente -> clienteEventPublisher.notificarTodos(cliente, "REMOVIDO"));
 	}
 
 	private void salvarClienteComCep(Cliente cliente) {

--- a/src/main/java/one/digitalinnovation/gof/service/impl/EmailNotificacaoObserver.java
+++ b/src/main/java/one/digitalinnovation/gof/service/impl/EmailNotificacaoObserver.java
@@ -1,0 +1,13 @@
+package one.digitalinnovation.gof.service.impl;
+
+import one.digitalinnovation.gof.model.Cliente;
+import one.digitalinnovation.gof.service.ClienteObserver;
+
+public class EmailNotificacaoObserver implements ClienteObserver {
+
+    @Override
+    public void notificar(Cliente cliente, String evento) {
+        System.out.printf("[E-MAIL] Cliente '%s' (id=%d) -> evento: %s%n", cliente.getNome(), cliente.getId(), evento);
+    }
+
+}

--- a/src/test/java/one/digitalinnovation/gof/ClienteEventPublisherTest.java
+++ b/src/test/java/one/digitalinnovation/gof/ClienteEventPublisherTest.java
@@ -1,0 +1,50 @@
+package one.digitalinnovation.gof;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+
+import one.digitalinnovation.gof.service.ClienteEventPublisher;
+import one.digitalinnovation.gof.service.ClienteObserver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import one.digitalinnovation.gof.model.Cliente;
+
+@ExtendWith(MockitoExtension.class)
+class ClienteEventPublisherTest {
+
+    @Mock
+    private ClienteObserver emailObserver;
+
+    @Mock
+    private ClienteObserver auditoriaObserver;
+
+    private ClienteEventPublisher clienteEventPublisher;
+
+    @BeforeEach
+    void setUp() {
+        clienteEventPublisher = new ClienteEventPublisher();
+        ReflectionTestUtils.setField(clienteEventPublisher, "observers",
+                Arrays.asList(emailObserver, auditoriaObserver));
+    }
+
+    @Test
+    void deveNotificarTodosOsObserversRegistrados() {
+        Cliente cliente = new Cliente();
+        cliente.setId(1L);
+        cliente.setNome("Maria");
+
+        clienteEventPublisher.notificarTodos(cliente, "CRIADO");
+
+        verify(emailObserver, times(1)).notificar(cliente, "CRIADO");
+        verify(auditoriaObserver, times(1)).notificar(cliente, "CRIADO");
+    }
+
+}
+

--- a/src/test/java/one/digitalinnovation/gof/service/impl/ClienteServiceImplTest.java
+++ b/src/test/java/one/digitalinnovation/gof/service/impl/ClienteServiceImplTest.java
@@ -1,0 +1,92 @@
+package one.digitalinnovation.gof.service.impl;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import one.digitalinnovation.gof.model.Cliente;
+import one.digitalinnovation.gof.model.ClienteRepository;
+import one.digitalinnovation.gof.model.Endereco;
+import one.digitalinnovation.gof.model.EnderecoRepository;
+import one.digitalinnovation.gof.service.ClienteEventPublisher;
+import one.digitalinnovation.gof.service.ViaCepService;
+
+
+@ExtendWith(MockitoExtension.class)
+class ClienteServiceImplTest {
+
+    @Mock
+    private ClienteRepository clienteRepository;
+    @Mock
+    private EnderecoRepository enderecoRepository;
+    @Mock
+    private ViaCepService viaCepService;
+    @Mock
+    private ClienteEventPublisher clienteEventPublisher;
+
+    @InjectMocks
+    private ClienteServiceImpl clienteService;
+
+    private Cliente cliente;
+
+    @BeforeEach
+    void setUp() {
+        Endereco endereco = new Endereco();
+        endereco.setCep("01001-000");
+
+        cliente = new Cliente();
+        cliente.setId(1L);
+        cliente.setNome("João");
+        cliente.setEndereco(endereco);
+
+        lenient().when(enderecoRepository.findById("01001-000")).thenReturn(Optional.of(endereco));
+    }
+
+    @Test
+    void deveNotificarObserversAoInserirCliente() {
+        clienteService.inserir(cliente);
+
+        verify(clienteRepository, times(1)).save(cliente);
+        verify(clienteEventPublisher, times(1)).notificarTodos(cliente, "CRIADO");
+    }
+
+    @Test
+    void deveNotificarObserversAoAtualizarCliente() {
+        when(clienteRepository.findById(1L)).thenReturn(Optional.of(cliente));
+
+        clienteService.atualizar(1L, cliente);
+
+        verify(clienteEventPublisher, times(1)).notificarTodos(cliente, "ATUALIZADO");
+    }
+
+    @Test
+    void naoDeveNotificarAoAtualizarClienteInexistente() {
+        when(clienteRepository.findById(99L)).thenReturn(Optional.empty());
+
+        clienteService.atualizar(99L, cliente);
+
+        verify(clienteEventPublisher, times(0)).notificarTodos(any(), any());
+    }
+
+    @Test
+    void deveNotificarObserversAoDeletarCliente() {
+        when(clienteRepository.findById(1L)).thenReturn(Optional.of(cliente));
+
+        clienteService.deletar(1L);
+
+        verify(clienteRepository, times(1)).deleteById(1L);
+        verify(clienteEventPublisher, times(1)).notificarTodos(cliente, "REMOVIDO");
+    }
+
+}


### PR DESCRIPTION
Adiciona o padrão de projeto Observer ao projeto. Foram criados ClienteObserver (interface) e ClienteEventPublisher (Subject) em service/, além de dois observers concretos (EmailNotificacaoObserver e AuditoriaObserver) em service/impl/, que simulam notificação por e-mail e registro de auditoria. O ClienteServiceImpl foi ajustado para publicar os eventos CRIADO, ATUALIZADO e REMOVIDO a cada operação de inserir, atualizar e deletar. Inclui testes unitários (ClienteEventPublisherTest e ClienteServiceImplTest) validando o disparo correto dos eventos.